### PR TITLE
Add ToSql support for GeometryCollectionC/T.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,8 @@ use diesel::deserialize::{self, FromSql};
 use diesel::pg::Pg;
 use diesel::serialize::{self, IsNull, Output, ToSql};
 use postgis::ewkb::{
-    AsEwkbLineString, AsEwkbMultiPolygon, AsEwkbPoint, AsEwkbPolygon, EwkbRead, EwkbWrite,
+    AsEwkbGeometryCollection, AsEwkbLineString, AsEwkbMultiPolygon, AsEwkbPoint, AsEwkbPolygon,
+    EwkbRead, EwkbWrite,
 };
 use postgis::*;
 
@@ -198,6 +199,7 @@ macro_rules! impl_to_sql_trait {
 impl_to_sql_trait!(PolygonT, PolygonC);
 impl_to_sql_trait!(LineStringT, LineStringC);
 impl_to_sql_trait!(MultiPolygonT, MultiPolygonC);
+impl_to_sql_trait!(GeometryCollectionT, GeometryCollectionC);
 
 impl_from_sql_trait!(LineString, LineStringT, "LineString", LineStringC);
 impl_from_sql_trait!(Polygon, PolygonT, "Polygon", PolygonC);


### PR DESCRIPTION
This completes the to/from sql for GeometryCollection, without this, read is possible, but not write.

Hi @vitaly-m this is the bare-minimum of support  and I have tested with an example project locally - I don't think this has any downsides - but let me know if there would be anything else useful to get this change through.