### PR TITLE
support Geography type

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Extension for Diesel framework to support PostGIS types. 
 
 # Example of Usage
-To ensure that the `Geometry` type is in scope, read [this guide] and add use `postgis_diesel::sql_types::*` 
+To ensure that the `Geometry` type is in scope, read [this guide] and add `use postgis_diesel::sql_types::*` 
 to the import_types key in your `diesel.toml` file.
 
 Assume that the table is defined like this:
@@ -48,6 +48,6 @@ table! {
     }
 }
 ```
-See [intergation test](tests/integration_test.rs) for more complete example.
+See [integration test](tests/integration_test.rs) for more complete example.
 
 [this guide]: http://diesel.rs/guides/configuring-diesel-cli/

--- a/src/geometrycollection.rs
+++ b/src/geometrycollection.rs
@@ -79,6 +79,15 @@ where
     }
 }
 
+impl<T> ToSql<Geography, Pg> for GeometryCollection<T>
+where
+    T: PointT + Debug + PartialEq + Clone + EwkbSerializable,
+{
+    fn to_sql(&self, out: &mut Output<Pg>) -> serialize::Result {
+        write_geometry_collection(self, self.srid, out)
+    }
+}
+
 impl<T> FromSql<Geometry, Pg> for GeometryCollection<T>
 where
     T: PointT + Debug + Clone,
@@ -91,6 +100,15 @@ where
         } else {
             read_geometry_collection::<LittleEndian, T>(&mut r)
         }
+    }
+}
+
+impl<T> FromSql<Geography, Pg> for GeometryCollection<T>
+where
+    T: PointT + Debug + Clone,
+{
+    fn from_sql(bytes: pg::PgValue) -> deserialize::Result<Self> {
+        FromSql::<Geometry, Pg>::from_sql(bytes)
     }
 }
 

--- a/src/linestring.rs
+++ b/src/linestring.rs
@@ -52,7 +52,25 @@ where
     }
 }
 
+impl<T> FromSql<Geography, Pg> for LineString<T>
+where
+    T: PointT + Debug + Clone,
+{
+    fn from_sql(bytes: pg::PgValue) -> deserialize::Result<Self> {
+        FromSql::<Geometry, Pg>::from_sql(bytes)
+    }
+}
+
 impl<T> ToSql<Geometry, Pg> for LineString<T>
+where
+    T: PointT + Debug + EwkbSerializable,
+{
+    fn to_sql(&self, out: &mut Output<Pg>) -> serialize::Result {
+        write_linestring(self, self.srid, out)
+    }
+}
+
+impl<T> ToSql<Geography, Pg> for LineString<T>
 where
     T: PointT + Debug + EwkbSerializable,
 {

--- a/src/multiline.rs
+++ b/src/multiline.rs
@@ -45,13 +45,13 @@ where
         self
     }
 
-    pub fn add_points<'a>(&'a mut self, points: &[T]) -> &mut Self {
+    pub fn add_points<'a>(&'a mut self, points: impl IntoIterator<Item = T>) -> &mut Self {
         if self.lines.last().is_none() {
             self.add_line();
         }
         let last = self.lines.last_mut().unwrap();
         for point in points {
-            last.points.push(point.to_owned());
+            last.points.push(point);
         }
         self
     }

--- a/src/multiline.rs
+++ b/src/multiline.rs
@@ -87,6 +87,15 @@ where
     }
 }
 
+impl<T> ToSql<Geography, Pg> for MultiLineString<T>
+where
+    T: PointT + Debug + PartialEq + EwkbSerializable + Clone,
+{
+    fn to_sql(&self, out: &mut Output<Pg>) -> serialize::Result {
+        write_multiline(self, self.srid, out)
+    }
+}
+
 impl<T> FromSql<Geometry, Pg> for MultiLineString<T>
 where
     T: PointT + Debug + Clone,
@@ -99,6 +108,15 @@ where
         } else {
             read_multiline::<LittleEndian, T>(&mut r)
         }
+    }
+}
+
+impl<T> FromSql<Geography, Pg> for MultiLineString<T>
+where
+    T: PointT + Debug + Clone,
+{
+    fn from_sql(bytes: pg::PgValue) -> deserialize::Result<Self> {
+        FromSql::<Geometry, Pg>::from_sql(bytes)
     }
 }
 

--- a/src/multipoint.rs
+++ b/src/multipoint.rs
@@ -57,7 +57,25 @@ where
     }
 }
 
+impl<T> FromSql<Geography, Pg> for MultiPoint<T>
+where
+    T: PointT + Debug + Clone,
+{
+    fn from_sql(bytes: pg::PgValue) -> deserialize::Result<Self> {
+        FromSql::<Geometry, Pg>::from_sql(bytes)
+    }
+}
+
 impl<T> ToSql<Geometry, Pg> for MultiPoint<T>
+where
+    T: PointT + Debug + EwkbSerializable,
+{
+    fn to_sql(&self, out: &mut Output<Pg>) -> serialize::Result {
+        write_multi_point(self, self.srid, out)
+    }
+}
+
+impl<T> ToSql<Geography, Pg> for MultiPoint<T>
 where
     T: PointT + Debug + EwkbSerializable,
 {

--- a/src/multipolygon.rs
+++ b/src/multipolygon.rs
@@ -36,20 +36,20 @@ where
     }
 
     pub fn add_point<'a>(&'a mut self, point: T) -> &mut Self {
-        if self.polygons.last().is_none() {
+        if self.polygons.is_empty() {
             self.add_empty_polygon();
         }
         self.polygons.last_mut().unwrap().add_point(point);
         self
     }
 
-    pub fn add_points<'a>(&'a mut self, points: &[T]) -> &mut Self {
-        if self.polygons.last().is_none() {
+    pub fn add_points<'a>(&'a mut self, points: impl IntoIterator<Item = T>) -> &mut Self {
+        if self.polygons.is_empty() {
             self.add_empty_polygon();
         }
         let last = self.polygons.last_mut().unwrap();
         for point in points {
-            last.add_point(point.to_owned());
+            last.add_point(point);
         }
         self
     }

--- a/src/multipolygon.rs
+++ b/src/multipolygon.rs
@@ -85,6 +85,15 @@ where
     }
 }
 
+impl<T> ToSql<Geography, Pg> for MultiPolygon<T>
+where
+    T: PointT + Debug + PartialEq + Clone + EwkbSerializable,
+{
+    fn to_sql(&self, out: &mut Output<Pg>) -> serialize::Result {
+        write_multi_polygon(self, self.srid, out)
+    }
+}
+
 impl<T> FromSql<Geometry, Pg> for MultiPolygon<T>
 where
     T: PointT + Debug + Clone,
@@ -97,6 +106,14 @@ where
         } else {
             read_multi_polygon::<LittleEndian, T>(&mut r)
         }
+    }
+}
+impl<T> FromSql<Geography, Pg> for MultiPolygon<T>
+where
+    T: PointT + Debug + Clone,
+{
+    fn from_sql(bytes: pg::PgValue) -> deserialize::Result<Self> {
+        FromSql::<Geometry, Pg>::from_sql(bytes)
     }
 }
 

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -1,6 +1,7 @@
 use diesel::expression::AsExpression;
 use diesel::sql_types::SqlType;
 use diesel::Expression;
+use crate::sql_types::Geography;
 
 diesel::infix_operator!(BBIntersects2D, " && ");
 diesel::infix_operator!(BBOverlapsOrLeft, " &< ");
@@ -21,6 +22,14 @@ diesel::infix_operator!(Distance3dTrajectories, " <-> ");
 diesel::infix_operator!(Distance2BBs, " <#> ");
 diesel::infix_operator!(DistanceNdCentroidsBBs, " <<->> ");
 diesel::infix_operator!(DistanceNdBBs, " <<#>> ");
+
+sql_function! {
+    /// ST_Intersects returns TRUE iff the intersection of the geometries or geographies is non-empty.
+    /// 
+    /// It is much faster than computing said intersection.
+    fn st_intersects(left: Geography, right: Geography) -> Bool;
+}
+pub type StIntersects<ExprLeft, ExprRight> = st_intersects::HelperType<ExprLeft, ExprRight>;
 
 /// The @ operator returns TRUE if the bounding box of geometry A is completely contained by the bounding box of geometry B.
 pub fn contained_by<T, U>(left: T, right: U) -> BBContainedBy<T, U::Expression>

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -183,7 +183,10 @@ where
 }
 
 /// The <<->> operator returns the n-D distance between the centroids of A and B bounding boxes.
-pub fn distance_nd_centroids_bbs<T, U>(left: T, right: U) -> DistanceNdCentroidsBBs<T, U::Expression>
+pub fn distance_nd_centroids_bbs<T, U>(
+    left: T,
+    right: U,
+) -> DistanceNdCentroidsBBs<T, U::Expression>
 where
     T: Expression,
     <T as diesel::Expression>::SqlType: SqlType,

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -40,13 +40,14 @@ where
         self
     }
 
-    pub fn add_points<'a>(&'a mut self, points: &[T]) -> &mut Self {
+    pub fn add_points<'a>(&'a mut self, points: impl IntoIterator<Item = T>) -> &mut Self
+    {
         if self.rings.last().is_none() {
             self.add_ring();
         }
         let last = self.rings.last_mut().unwrap();
         for point in points {
-            last.push(point.to_owned());
+            last.push(point);
         }
         self
     }

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -80,6 +80,15 @@ where
     }
 }
 
+impl<T> ToSql<Geography, Pg> for Polygon<T>
+where
+    T: PointT + Debug + PartialEq + Clone + EwkbSerializable,
+{
+    fn to_sql(&self, out: &mut Output<Pg>) -> serialize::Result {
+        write_polygon(self, self.srid, out)
+    }
+}
+
 pub fn write_polygon<T>(
     polygon: &Polygon<T>,
     srid: Option<u32>,
@@ -113,6 +122,15 @@ where
         } else {
             read_polygon::<LittleEndian, T>(&mut r)
         }
+    }
+}
+
+impl<T> FromSql<Geography, Pg> for Polygon<T>
+where
+    T: PointT + Debug + Clone,
+{
+    fn from_sql(bytes: pg::PgValue) -> deserialize::Result<Self> {
+        FromSql::<Geometry, Pg>::from_sql(bytes)
     }
 }
 

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -14,3 +14,7 @@
 #[derive(SqlType, QueryId)]
 #[diesel(postgres_type(name = "geometry"))]
 pub struct Geometry;
+
+#[derive(SqlType, QueryId)]
+#[diesel(postgres_type(name = "geography"))]
+pub struct Geography;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,9 @@
 use std::fmt;
 
+use crate::sql_types::Geography;
 use crate::sql_types::Geometry;
 
-/// Error which may be returned if point cinstructed without required fields or has some unexpected fields for type.
+/// Error which may be returned if point constructed without required fields or has some unexpected fields for type.
 /// ```
 /// use postgis_diesel::types::{PointT, PointZ, Point, PointConstructorError};
 /// let point = PointZ::new_point(72.0, 63.0, None, None, None);
@@ -37,6 +38,7 @@ impl std::error::Error for PointConstructorError {}
 /// ```
 #[derive(Copy, Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
 #[diesel(sql_type = Geometry)]
+#[diesel(sql_type = Geography)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Point {
     pub x: f64,
@@ -57,6 +59,7 @@ pub struct Point {
 /// ```
 #[derive(Copy, Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
 #[diesel(sql_type = Geometry)]
+#[diesel(sql_type = Geography)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PointZ {
     pub x: f64,
@@ -78,6 +81,7 @@ pub struct PointZ {
 /// ```
 #[derive(Copy, Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
 #[diesel(sql_type = Geometry)]
+#[diesel(sql_type = Geography)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PointM {
     pub x: f64,
@@ -99,6 +103,7 @@ pub struct PointM {
 /// ```
 #[derive(Copy, Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
 #[diesel(sql_type = Geometry)]
+#[diesel(sql_type = Geography)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PointZM {
     pub x: f64,
@@ -109,6 +114,7 @@ pub struct PointZM {
     pub srid: Option<u32>,
 }
 
+/// Allows uniform access across the four point types
 pub trait PointT {
     fn new_point(
         x: f64,
@@ -139,6 +145,7 @@ pub trait PointT {
 /// ```
 #[derive(Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
 #[diesel(sql_type = Geometry)]
+#[diesel(sql_type = Geography)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MultiPoint<T> {
     pub points: Vec<T>,
@@ -158,6 +165,7 @@ pub struct MultiPoint<T> {
 /// ```
 #[derive(Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
 #[diesel(sql_type = Geometry)]
+#[diesel(sql_type = Geography)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LineString<T> {
     pub points: Vec<T>,
@@ -177,6 +185,7 @@ pub struct LineString<T> {
 /// ```
 #[derive(Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
 #[diesel(sql_type = Geometry)]
+#[diesel(sql_type = Geography)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MultiLineString<T> {
     pub lines: Vec<LineString<T>>,
@@ -196,6 +205,7 @@ pub struct MultiLineString<T> {
 /// ```
 #[derive(Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
 #[diesel(sql_type = Geometry)]
+#[diesel(sql_type = Geography)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Polygon<T> {
     pub rings: Vec<Vec<T>>,
@@ -215,6 +225,7 @@ pub struct Polygon<T> {
 /// ```
 #[derive(Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
 #[diesel(sql_type = Geometry)]
+#[diesel(sql_type = Geography)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MultiPolygon<T> {
     pub polygons: Vec<Polygon<T>>,
@@ -222,6 +233,9 @@ pub struct MultiPolygon<T> {
     pub srid: Option<u32>,
 }
 
+/// Represents any type that can appear in a geometry or geography column.
+///
+/// T is the Point type (Point or PointZ or PointM)
 #[derive(Clone, Debug, PartialEq, FromSqlRow)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum GeometryContainer<T> {
@@ -246,6 +260,7 @@ pub enum GeometryContainer<T> {
 /// ```
 #[derive(Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
 #[diesel(sql_type = Geometry)]
+#[diesel(sql_type = Geography)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GeometryCollection<T> {
     pub geometries: Vec<GeometryContainer<T>>,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -270,20 +270,20 @@ fn new_geometry_collection() -> GeometryCollection<Point> {
         new_point(72.0, 64.0),
     ]);
     let mut multiline = MultiLineString::new(Some(4326));
-    multiline.add_points(&vec![new_point(72.0, 64.0), new_point(73.0, 65.0)]);
+    multiline.add_points([new_point(72.0, 64.0), new_point(73.0, 65.0)]);
     multiline.add_line();
-    multiline.add_points(&vec![new_point(71.0, 62.0), new_point(72.0, 64.0)]);
+    multiline.add_points([new_point(71.0, 62.0), new_point(72.0, 64.0)]);
     let mut multipolygon = MultiPolygon::new(Some(4326));
     multipolygon
         .add_empty_polygon()
-        .add_points(&vec![
+        .add_points([
             new_point(72.0, 64.0),
             new_point(73.0, 65.0),
             new_point(71.0, 62.0),
             new_point(72.0, 64.0),
         ])
         .add_empty_polygon()
-        .add_points(&vec![
+        .add_points([
             new_point(75.0, 64.0),
             new_point(74.0, 65.0),
             new_point(74.0, 62.0),
@@ -327,20 +327,20 @@ fn smoke_test() {
         new_point(72.0, 64.0),
     ]);
     let mut multiline = MultiLineString::new(Some(4326));
-    multiline.add_points(&vec![new_point(72.0, 64.0), new_point(73.0, 65.0)]);
+    multiline.add_points([new_point(72.0, 64.0), new_point(73.0, 65.0)]);
     multiline.add_line();
-    multiline.add_points(&vec![new_point(71.0, 62.0), new_point(72.0, 64.0)]);
+    multiline.add_points([new_point(71.0, 62.0), new_point(72.0, 64.0)]);
     let mut multipolygon = MultiPolygon::new(Some(4326));
     multipolygon
         .add_empty_polygon()
-        .add_points(&vec![
+        .add_points([
             new_point(72.0, 64.0),
             new_point(73.0, 65.0),
             new_point(71.0, 62.0),
             new_point(72.0, 64.0),
         ])
         .add_empty_polygon()
-        .add_points(&vec![
+        .add_points([
             new_point(75.0, 64.0),
             new_point(74.0, 65.0),
             new_point(74.0, 62.0),
@@ -395,20 +395,20 @@ fn geography_smoke_test() {
         new_point(72.0, 64.0),
     ]);
     let mut multiline = MultiLineString::new(Some(4326));
-    multiline.add_points(&vec![new_point(72.0, 64.0), new_point(73.0, 65.0)]);
+    multiline.add_points([new_point(72.0, 64.0), new_point(73.0, 65.0)]);
     multiline.add_line();
-    multiline.add_points(&vec![new_point(71.0, 62.0), new_point(72.0, 64.0)]);
+    multiline.add_points([new_point(71.0, 62.0), new_point(72.0, 64.0)]);
     let mut multipolygon = MultiPolygon::new(Some(4326));
     multipolygon
         .add_empty_polygon()
-        .add_points(&vec![
+        .add_points([
             new_point(72.0, 64.0),
             new_point(73.0, 65.0),
             new_point(71.0, 62.0),
             new_point(72.0, 64.0),
         ])
         .add_empty_polygon()
-        .add_points(&vec![
+        .add_points([
             new_point(75.0, 64.0),
             new_point(74.0, 65.0),
             new_point(74.0, 62.0),
@@ -533,20 +533,20 @@ macro_rules! operator_test {
                 new_point(72.0, 64.0),
             ]);
             let mut multiline = MultiLineString::new(Some(4326));
-            multiline.add_points(&vec![new_point(72.0, 64.0), new_point(73.0, 65.0)]);
+            multiline.add_points([new_point(72.0, 64.0), new_point(73.0, 65.0)]);
             multiline.add_line();
-            multiline.add_points(&vec![new_point(71.0, 62.0), new_point(72.0, 64.0)]);
+            multiline.add_points([new_point(71.0, 62.0), new_point(72.0, 64.0)]);
             let mut multipolygon = MultiPolygon::new(Some(4326));
             multipolygon
                 .add_empty_polygon()
-                .add_points(&vec![
+                .add_points([
                     new_point(72.0, 64.0),
                     new_point(73.0, 65.0),
                     new_point(71.0, 62.0),
                     new_point(72.0, 64.0),
                 ])
                 .add_empty_polygon()
-                .add_points(&vec![
+                .add_points([
                     new_point(75.0, 64.0),
                     new_point(74.0, 65.0),
                     new_point(74.0, 62.0),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -28,7 +28,7 @@ struct NewGeometrySample {
     multipoint: MultiPoint<Point>,
     multiline: MultiLineString<Point>,
     multipolygon: MultiPolygon<Point>,
-    gemetrycollection: GeometryCollection<Point>,
+    geometrycollection: GeometryCollection<Point>,
 }
 
 #[derive(Insertable)]
@@ -37,6 +37,22 @@ struct NewDistanceSample {
     name: String,
     point: Point,
     polygon: Polygon<Point>,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = geography_samples)]
+struct NewGeographySample {
+    name: String,
+    point: Point,
+    point_z: PointZ,
+    point_m: PointM,
+    point_zm: PointZM,
+    linestring: LineString<Point>,
+    polygon: Polygon<Point>,
+    multipoint: MultiPoint<Point>,
+    multiline: MultiLineString<Point>,
+    multipolygon: MultiPolygon<Point>,
+    geometrycollection: GeometryCollection<Point>,
 }
 
 #[derive(Queryable, Debug, PartialEq)]
@@ -52,7 +68,7 @@ struct GeometrySample {
     multipoint: MultiPoint<Point>,
     multiline: MultiLineString<Point>,
     multipolygon: MultiPolygon<Point>,
-    gemetrycollection: GeometryCollection<Point>,
+    geometrycollection: GeometryCollection<Point>,
 }
 
 #[derive(Queryable, Debug, PartialEq)]
@@ -62,6 +78,22 @@ struct DistanceSample {
     name: String,
     point: Point,
     polygon: Polygon<Point>,
+}
+
+#[derive(Queryable, Debug, PartialEq)]
+struct GeographySample {
+    id: i32,
+    name: String,
+    point: Point,
+    point_z: PointZ,
+    point_m: PointM,
+    point_zm: PointZM,
+    linestring: LineString<Point>,
+    polygon: Polygon<Point>,
+    multipoint: MultiPoint<Point>,
+    multiline: MultiLineString<Point>,
+    multipolygon: MultiPolygon<Point>,
+    geometrycollection: GeometryCollection<Point>,
 }
 
 table! {
@@ -79,7 +111,7 @@ table! {
         multipoint -> Geometry,
         multiline -> Geometry,
         multipolygon -> Geometry,
-        gemetrycollection -> Geometry,
+        geometrycollection -> Geometry,
     }
 }
 
@@ -94,6 +126,24 @@ table! {
     }
 }
 
+table! {
+    use postgis_diesel::sql_types::*;
+    use diesel::sql_types::*;
+    geography_samples (id) {
+        id -> Int4,
+        name -> Text,
+        point -> Geography,
+        point_z -> Geography,
+        point_m -> Geography,
+        point_zm -> Geography,
+        linestring -> Geography,
+        polygon -> Geography,
+        multipoint -> Geography,
+        multiline -> Geography,
+        multipolygon -> Geography,
+        geometrycollection -> Geography,
+    }
+}
 fn establish_connection() -> PgConnection {
     dotenv().ok();
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL not set");
@@ -107,6 +157,7 @@ fn initialize() -> PgConnection {
         let _ = diesel::sql_query("CREATE EXTENSION IF NOT EXISTS postgis").execute(&mut conn);
         let _ = diesel::sql_query("DROP TABLE geometry_samples").execute(&mut conn);
         let _ = diesel::sql_query("DROP TABLE distance_samples").execute(&mut conn);
+        let _ = diesel::sql_query("DROP TABLE geography_samples").execute(&mut conn);
 
         let _ = diesel::sql_query(
             "CREATE TABLE geometry_samples
@@ -122,7 +173,7 @@ fn initialize() -> PgConnection {
     multipoint        geometry(MultiPoint,4326) NOT NULL,
     multiline         geometry(MultiLineString,4326) NOT NULL,
     multipolygon      geometry(MultiPolygon,4326) NOT NULL,
-    gemetrycollection geometry(GeometryCollection,4326) NOT NULL
+    geometrycollection geometry(GeometryCollection,4326) NOT NULL
 )",
         )
         .execute(&mut conn);
@@ -133,6 +184,25 @@ fn initialize() -> PgConnection {
     name              text,
     point             geometry(Point,4326) NOT NULL,
     polygon           geometry(Polygon,4326) NOT NULL
+)",
+        )
+        .execute(&mut conn);
+
+        let _ = diesel::sql_query(
+            "CREATE TABLE geography_samples
+(
+    id                SERIAL PRIMARY KEY,
+    name              text,
+    point             geography(Point,4326) NOT NULL,
+    point_z           geography(PointZ,4326) NOT NULL,
+    point_m           geography(PointM,4326) NOT NULL,
+    point_zm          geography(PointZM,4326) NOT NULL,
+    linestring        geography(Linestring,4326) NOT NULL,
+    polygon           geography(Polygon,4326) NOT NULL,
+    multipoint        geography(MultiPoint,4326) NOT NULL,
+    multiline         geography(MultiLineString,4326) NOT NULL,
+    multipolygon      geography(MultiPolygon,4326) NOT NULL,
+    geometrycollection geography(GeometryCollection,4326) NOT NULL
 )",
         )
         .execute(&mut conn);
@@ -290,7 +360,7 @@ fn smoke_test() {
         },
         multiline: multiline,
         multipolygon: multipolygon,
-        gemetrycollection: new_geometry_collection(),
+        geometrycollection: new_geometry_collection(),
     };
     let point_from_db: GeometrySample = diesel::insert_into(geometry_samples::table)
         .values(&sample)
@@ -307,7 +377,75 @@ fn smoke_test() {
     assert_eq!(sample.multipoint, point_from_db.multipoint);
     assert_eq!(sample.multiline, point_from_db.multiline);
     assert_eq!(sample.multipolygon, point_from_db.multipolygon);
-    assert_eq!(sample.gemetrycollection, point_from_db.gemetrycollection);
+    assert_eq!(sample.geometrycollection, point_from_db.geometrycollection);
+
+    let _ =
+        diesel::delete(geometry_samples::table.filter(geometry_samples::id.eq(point_from_db.id)))
+            .execute(&mut conn);
+}
+
+#[test]
+fn geography_smoke_test() {
+    let mut conn = initialize();
+    let mut polygon = Polygon::new(Some(4326));
+    polygon.add_points(&vec![
+        new_point(72.0, 64.0),
+        new_point(73.0, 65.0),
+        new_point(71.0, 62.0),
+        new_point(72.0, 64.0),
+    ]);
+    let mut multiline = MultiLineString::new(Some(4326));
+    multiline.add_points(&vec![new_point(72.0, 64.0), new_point(73.0, 65.0)]);
+    multiline.add_line();
+    multiline.add_points(&vec![new_point(71.0, 62.0), new_point(72.0, 64.0)]);
+    let mut multipolygon = MultiPolygon::new(Some(4326));
+    multipolygon
+        .add_empty_polygon()
+        .add_points(&vec![
+            new_point(72.0, 64.0),
+            new_point(73.0, 65.0),
+            new_point(71.0, 62.0),
+            new_point(72.0, 64.0),
+        ])
+        .add_empty_polygon()
+        .add_points(&vec![
+            new_point(75.0, 64.0),
+            new_point(74.0, 65.0),
+            new_point(74.0, 62.0),
+            new_point(75.0, 64.0),
+        ]);
+    let sample = NewGeographySample {
+        name: String::from("smoke_test"),
+        point: new_point(72.0, 64.0),
+        point_z: new_point_z(72.0, 64.0, 10.0),
+        point_m: new_point_m(72.0, 64.0, 11.0),
+        point_zm: new_point_zm(72.0, 64.0, 10.0, 11.0),
+        linestring: new_line(vec![(72.0, 64.0), (73.0, 64.0)]),
+        polygon: polygon,
+        multipoint: MultiPoint {
+            points: vec![new_point(72.0, 64.0), new_point(73.0, 64.0)],
+            srid: Some(4326),
+        },
+        multiline: multiline,
+        multipolygon: multipolygon,
+        geometrycollection: new_geometry_collection(),
+    };
+    let point_from_db: GeographySample = diesel::insert_into(geography_samples::table)
+        .values(&sample)
+        .get_result(&mut conn)
+        .expect("Error saving geometry sample");
+
+    assert_eq!(sample.name, point_from_db.name);
+    assert_eq!(sample.point, point_from_db.point);
+    assert_eq!(sample.point_z, point_from_db.point_z);
+    assert_eq!(sample.point_m, point_from_db.point_m);
+    assert_eq!(sample.point_zm, point_from_db.point_zm);
+    assert_eq!(sample.linestring, point_from_db.linestring);
+    assert_eq!(sample.polygon, point_from_db.polygon);
+    assert_eq!(sample.multipoint, point_from_db.multipoint);
+    assert_eq!(sample.multiline, point_from_db.multiline);
+    assert_eq!(sample.multipolygon, point_from_db.multipolygon);
+    assert_eq!(sample.geometrycollection, point_from_db.geometrycollection);
 
     let _ =
         diesel::delete(geometry_samples::table.filter(geometry_samples::id.eq(point_from_db.id)))
@@ -428,7 +566,7 @@ macro_rules! operator_test {
                 },
                 multiline: multiline,
                 multipolygon: multipolygon,
-                gemetrycollection: new_geometry_collection(),
+                geometrycollection: new_geometry_collection(),
             };
             let _ = diesel::insert_into(geometry_samples::table)
                 .values(&sample)

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -263,7 +263,7 @@ fn new_point_zm(x: f64, y: f64, z: f64, m: f64) -> PointZM {
 
 fn new_geometry_collection() -> GeometryCollection<Point> {
     let mut polygon = Polygon::new(Some(4326));
-    polygon.add_points(&vec![
+    polygon.add_points([
         new_point(72.0, 64.0),
         new_point(73.0, 65.0),
         new_point(71.0, 62.0),
@@ -320,7 +320,7 @@ fn new_geometry_collection() -> GeometryCollection<Point> {
 fn smoke_test() {
     let mut conn = initialize();
     let mut polygon = Polygon::new(Some(4326));
-    polygon.add_points(&vec![
+    polygon.add_points([
         new_point(72.0, 64.0),
         new_point(73.0, 65.0),
         new_point(71.0, 62.0),
@@ -388,7 +388,7 @@ fn smoke_test() {
 fn geography_smoke_test() {
     let mut conn = initialize();
     let mut polygon = Polygon::new(Some(4326));
-    polygon.add_points(&vec![
+    polygon.add_points([
         new_point(72.0, 64.0),
         new_point(73.0, 65.0),
         new_point(71.0, 62.0),
@@ -526,7 +526,7 @@ macro_rules! operator_test {
         fn $t() {
             let mut conn = initialize();
             let mut polygon = Polygon::new(Some(4326));
-            polygon.add_points(&vec![
+            polygon.add_points([
                 new_point(72.0, 64.0),
                 new_point(73.0, 65.0),
                 new_point(71.0, 62.0),


### PR DESCRIPTION
This PR adds support for PostGIS Geography. Geography has a basically identical interface to Geometry - it supports all the same types of lines, polygons, etc. - but it works with lat-long data instead of Euclidean space. The code change needed to support this is small but it greatly increases the reach and applicability of the library. I've also included code to register the st_intersects PostGIS function, mainly as an example to show how other functions can be added.

At the same time, I've made the interface more ergonomic: various `add_points` builder methods that previously took a slice now take `IntoIterator` instead. This is a breaking change (I haven't incremented the version number because I'm not sure what your release procedure is) but it brings the interface into line with best practice: it allows us to take ownership of the individual items directly instead of copying them one at a time with `.to_owned`, and it means you can initialize with any container, not just an array or vec.

As a housekeeping note: I'm submitting this on behalf of my employer Helsing Ltd., who holds the copyright on this change. Helsing Ltd. releases this code under the project's MIT license.