### PR TITLE
Remove postgres dependency, add to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,12 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diesel = { version = "2.0", features = ["postgres", "postgres_backend"] }
+diesel = { version = "2.0", features = ["postgres_backend"] }
 byteorder = "1.4"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
+diesel = { version = "2.0", features = ["postgres"] }
 dotenv = "0.15.0"
 serde_json = "1.0"
 


### PR DESCRIPTION
This PR removes `postgres` from the list of diesel features required for the crate, and adds it to the list of dev-dependencies so the integration tests continue to pass.

With the addition of the `postgres_backend` api, `postgres` actually isn't required anymore- and including it in the list of diesel dependencies means that OpenSSL is linked even if an alternate postgres implementation is used.