### PR TITLE
add sql mappings for GeometryContainer

### DIFF
--- a/src/geometrycollection.rs
+++ b/src/geometrycollection.rs
@@ -20,23 +20,6 @@ use diesel::{
 
 use crate::sql_types::*;
 
-impl<T> GeometryContainer<T>
-where
-    T: PointT + Clone,
-{
-    pub fn dimension(&self) -> u32 {
-        match self {
-            GeometryContainer::Point(g) => g.dimension(),
-            GeometryContainer::LineString(g) => g.dimension(),
-            GeometryContainer::Polygon(g) => g.dimension(),
-            GeometryContainer::MultiPoint(g) => g.dimension(),
-            GeometryContainer::MultiLineString(g) => g.dimension(),
-            GeometryContainer::MultiPolygon(g) => g.dimension(),
-            GeometryContainer::GeometryCollection(g) => g.dimension(),
-        }
-    }
-}
-
 impl<T> GeometryCollection<T>
 where
     T: PointT + Clone,
@@ -158,7 +141,7 @@ where
     T: byteorder::ByteOrder,
     P: PointT + Clone,
 {
-    let g_header = read_ewkb_header::<T>(GeometryType::GeometryCollection, cursor)?;
+    let g_header = read_ewkb_header::<T>(cursor)?.expect(GeometryType::GeometryCollection)?;
     read_geometry_collection_body::<T, P>(g_header.g_type, g_header.srid, cursor)
 }
 

--- a/src/geometrycontainer.rs
+++ b/src/geometrycontainer.rs
@@ -1,0 +1,207 @@
+use std::fmt::Debug;
+use std::io::Cursor;
+
+use crate::{
+    ewkb::{read_ewkb_header, EwkbSerializable, GeometryType, BIG_ENDIAN},
+    geometrycollection::{read_geometry_collection_body, write_geometry_collection},
+    linestring::{read_linestring_body, write_linestring},
+    multiline::{read_multiline_body, write_multiline},
+    multipoint::{read_multi_point_body, write_multi_point},
+    multipolygon::{read_multi_polygon_body, write_multi_polygon},
+    points::{read_point_coordinates, write_point},
+    polygon::*,
+    sql_types::{Geography, Geometry},
+    types::*,
+};
+use byteorder::{BigEndian, LittleEndian};
+use diesel::{
+    deserialize::{self, FromSql},
+    pg::{self, Pg},
+    serialize::{self, Output, ToSql},
+};
+
+impl<T> GeometryContainer<T>
+where
+    T: PointT + Clone,
+{
+    pub fn dimension(&self) -> u32 {
+        match self {
+            GeometryContainer::Point(g) => g.dimension(),
+            GeometryContainer::LineString(g) => g.dimension(),
+            GeometryContainer::Polygon(g) => g.dimension(),
+            GeometryContainer::MultiPoint(g) => g.dimension(),
+            GeometryContainer::MultiLineString(g) => g.dimension(),
+            GeometryContainer::MultiPolygon(g) => g.dimension(),
+            GeometryContainer::GeometryCollection(g) => g.dimension(),
+        }
+    }
+}
+
+impl<T> ToSql<Geometry, Pg> for GeometryContainer<T>
+where
+    T: PointT + Debug + PartialEq + Clone + EwkbSerializable + ToSql<Geometry, Pg>,
+{
+    fn to_sql(&self, out: &mut Output<Pg>) -> serialize::Result {
+        match self {
+            GeometryContainer::Point(g) => write_point(g, g.get_srid(), out),
+            GeometryContainer::MultiPoint(g) => write_multi_point(g, g.srid, out),
+            GeometryContainer::LineString(g) => write_linestring(g, g.srid, out),
+            GeometryContainer::MultiLineString(g) => write_multiline(g, g.srid, out),
+            GeometryContainer::Polygon(g) => write_polygon(g, g.srid, out),
+            GeometryContainer::MultiPolygon(g) => write_multi_polygon(g, g.srid, out),
+            GeometryContainer::GeometryCollection(g) => write_geometry_collection(g, g.srid, out),
+        }
+    }
+}
+
+impl<T> ToSql<Geography, Pg> for GeometryContainer<T>
+where
+    T: PointT + Debug + PartialEq + Clone + EwkbSerializable + ToSql<Geometry, Pg>,
+{
+    fn to_sql(&self, out: &mut Output<Pg>) -> serialize::Result {
+        match self {
+            GeometryContainer::Point(g) => write_point(g, g.get_srid(), out),
+            GeometryContainer::MultiPoint(g) => write_multi_point(g, g.srid, out),
+            GeometryContainer::LineString(g) => write_linestring(g, g.srid, out),
+            GeometryContainer::MultiLineString(g) => write_multiline(g, g.srid, out),
+            GeometryContainer::Polygon(g) => write_polygon(g, g.srid, out),
+            GeometryContainer::MultiPolygon(g) => write_multi_polygon(g, g.srid, out),
+            GeometryContainer::GeometryCollection(g) => write_geometry_collection(g, g.srid, out),
+        }
+    }
+}
+
+impl<T> FromSql<Geometry, Pg> for GeometryContainer<T>
+where
+    T: PointT + Debug + Clone + FromSql<Geometry, Pg>,
+{
+    fn from_sql(bytes: pg::PgValue) -> deserialize::Result<Self> {
+        use byteorder::ReadBytesExt;
+
+        let mut cursor = Cursor::new(bytes.as_bytes());
+        let end = cursor.read_u8()?;
+        let container = if end == BIG_ENDIAN {
+            let g_header = read_ewkb_header::<BigEndian>(&mut cursor)?;
+            match GeometryType::from(g_header.g_type) {
+                GeometryType::Point => {
+                    GeometryContainer::Point(read_point_coordinates::<BigEndian, T>(
+                        &mut cursor,
+                        g_header.g_type,
+                        g_header.srid,
+                    )?)
+                }
+                GeometryType::MultiPoint => {
+                    GeometryContainer::MultiPoint(read_multi_point_body::<BigEndian, T>(
+                        g_header.g_type,
+                        g_header.srid,
+                        &mut cursor,
+                    )?)
+                }
+                GeometryType::LineString => {
+                    GeometryContainer::LineString(read_linestring_body::<BigEndian, T>(
+                        g_header.g_type,
+                        g_header.srid,
+                        &mut cursor,
+                    )?)
+                }
+                GeometryType::MultiLineString => {
+                    GeometryContainer::MultiLineString(read_multiline_body::<BigEndian, T>(
+                        g_header.g_type,
+                        g_header.srid,
+                        &mut cursor,
+                    )?)
+                }
+                GeometryType::Polygon => {
+                    GeometryContainer::Polygon(read_polygon_body::<BigEndian, T>(
+                        g_header.g_type,
+                        g_header.srid,
+                        &mut cursor,
+                    )?)
+                }
+                GeometryType::MultiPolygon => {
+                    GeometryContainer::MultiPolygon(read_multi_polygon_body::<BigEndian, T>(
+                        g_header.g_type,
+                        g_header.srid,
+                        &mut cursor,
+                    )?)
+                }
+                GeometryType::GeometryCollection => {
+                    GeometryContainer::GeometryCollection(read_geometry_collection_body::<
+                        BigEndian,
+                        T,
+                    >(
+                        g_header.g_type,
+                        g_header.srid,
+                        &mut cursor,
+                    )?)
+                }
+            }
+        } else {
+            let g_header = read_ewkb_header::<LittleEndian>(&mut cursor)?;
+            match GeometryType::from(g_header.g_type) {
+                GeometryType::Point => {
+                    GeometryContainer::Point(read_point_coordinates::<LittleEndian, T>(
+                        &mut cursor,
+                        g_header.g_type,
+                        g_header.srid,
+                    )?)
+                }
+                GeometryType::MultiPoint => {
+                    GeometryContainer::MultiPoint(read_multi_point_body::<LittleEndian, T>(
+                        g_header.g_type,
+                        g_header.srid,
+                        &mut cursor,
+                    )?)
+                }
+                GeometryType::LineString => {
+                    GeometryContainer::LineString(read_linestring_body::<LittleEndian, T>(
+                        g_header.g_type,
+                        g_header.srid,
+                        &mut cursor,
+                    )?)
+                }
+                GeometryType::MultiLineString => {
+                    GeometryContainer::MultiLineString(read_multiline_body::<LittleEndian, T>(
+                        g_header.g_type,
+                        g_header.srid,
+                        &mut cursor,
+                    )?)
+                }
+                GeometryType::Polygon => {
+                    GeometryContainer::Polygon(read_polygon_body::<LittleEndian, T>(
+                        g_header.g_type,
+                        g_header.srid,
+                        &mut cursor,
+                    )?)
+                }
+                GeometryType::MultiPolygon => {
+                    GeometryContainer::MultiPolygon(read_multi_polygon_body::<LittleEndian, T>(
+                        g_header.g_type,
+                        g_header.srid,
+                        &mut cursor,
+                    )?)
+                }
+                GeometryType::GeometryCollection => {
+                    GeometryContainer::GeometryCollection(read_geometry_collection_body::<
+                        LittleEndian,
+                        T,
+                    >(
+                        g_header.g_type,
+                        g_header.srid,
+                        &mut cursor,
+                    )?)
+                }
+            }
+        };
+        Ok(container)
+    }
+}
+
+impl<T> FromSql<Geography, Pg> for GeometryContainer<T>
+where
+    T: PointT + Debug + Clone + FromSql<Geometry, Pg>,
+{
+    fn from_sql(bytes: pg::PgValue) -> deserialize::Result<Self> {
+        FromSql::<Geometry, Pg>::from_sql(bytes)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate serde;
 mod ewkb;
 pub mod functions;
 mod geometrycollection;
+mod geometrycontainer;
 mod linestring;
 mod multiline;
 mod multipoint;

--- a/src/linestring.rs
+++ b/src/linestring.rs
@@ -124,7 +124,7 @@ where
     T: byteorder::ByteOrder,
     P: PointT + Clone,
 {
-    let g_header = read_ewkb_header::<T>(GeometryType::LineString, cursor)?;
+    let g_header = read_ewkb_header::<T>(cursor)?.expect(GeometryType::LineString)?;
     read_linestring_body::<T, P>(g_header.g_type, g_header.srid, cursor)
 }
 

--- a/src/multiline.rs
+++ b/src/multiline.rs
@@ -147,7 +147,7 @@ where
     T: byteorder::ByteOrder,
     P: PointT + Clone,
 {
-    let g_header = read_ewkb_header::<T>(GeometryType::MultiLineString, cursor)?;
+    let g_header = read_ewkb_header::<T>(cursor)?.expect(GeometryType::MultiLineString)?;
     read_multiline_body::<T, P>(g_header.g_type, g_header.srid, cursor)
 }
 

--- a/src/multipoint.rs
+++ b/src/multipoint.rs
@@ -129,7 +129,7 @@ where
     T: byteorder::ByteOrder,
     P: PointT + Clone,
 {
-    let g_header = read_ewkb_header::<T>(GeometryType::MultiPoint, cursor)?;
+    let g_header = read_ewkb_header::<T>(cursor)?.expect(GeometryType::MultiPoint)?;
     read_multi_point_body::<T, P>(g_header.g_type, g_header.srid, cursor)
 }
 

--- a/src/multipolygon.rs
+++ b/src/multipolygon.rs
@@ -147,7 +147,7 @@ where
     T: byteorder::ByteOrder,
     P: PointT + Clone,
 {
-    let g_header = read_ewkb_header::<T>(GeometryType::MultiPolygon, cursor)?;
+    let g_header = read_ewkb_header::<T>(cursor)?.expect(GeometryType::MultiPolygon)?;
     read_multi_polygon_body::<T, P>(g_header.g_type, g_header.srid, cursor)
 }
 

--- a/src/points.rs
+++ b/src/points.rs
@@ -326,7 +326,7 @@ where
     T: byteorder::ByteOrder,
     P: PointT,
 {
-    let g_header = read_ewkb_header::<T>(GeometryType::Point, cursor)?;
+    let g_header = read_ewkb_header::<T>(cursor)?.expect(GeometryType::Point)?;
     read_point_coordinates::<T, P>(cursor, g_header.g_type, g_header.srid)
 }
 

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -147,7 +147,7 @@ where
     T: byteorder::ByteOrder,
     P: PointT + Clone,
 {
-    let g_header = read_ewkb_header::<T>(GeometryType::Polygon, cursor)?;
+    let g_header = read_ewkb_header::<T>(cursor)?.expect(GeometryType::Polygon)?;
     read_polygon_body::<T, P>(g_header.g_type, g_header.srid, cursor)
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -236,7 +236,9 @@ pub struct MultiPolygon<T> {
 /// Represents any type that can appear in a geometry or geography column.
 ///
 /// T is the Point type (Point or PointZ or PointM)
-#[derive(Clone, Debug, PartialEq, FromSqlRow)]
+#[derive(Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
+#[diesel(sql_type = Geometry)]
+#[diesel(sql_type = Geography)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum GeometryContainer<T> {
     Point(T),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -29,6 +29,7 @@ struct NewGeometrySample {
     multiline: MultiLineString<Point>,
     multipolygon: MultiPolygon<Point>,
     geometrycollection: GeometryCollection<Point>,
+    geometrycontainer: GeometryContainer<Point>,
 }
 
 #[derive(Insertable)]
@@ -60,6 +61,7 @@ struct NewGeographySample {
     multiline: MultiLineString<Point>,
     multipolygon: MultiPolygon<Point>,
     geometrycollection: GeometryCollection<Point>,
+    geometrycontainer: GeometryContainer<Point>,
 }
 
 #[derive(Queryable, Debug, PartialEq)]
@@ -76,6 +78,7 @@ struct GeometrySample {
     multiline: MultiLineString<Point>,
     multipolygon: MultiPolygon<Point>,
     geometrycollection: GeometryCollection<Point>,
+    geometrycontainer: GeometryContainer<Point>,
 }
 
 #[derive(Queryable, Debug, PartialEq)]
@@ -109,6 +112,7 @@ struct GeographySample {
     multiline: MultiLineString<Point>,
     multipolygon: MultiPolygon<Point>,
     geometrycollection: GeometryCollection<Point>,
+    geometrycontainer: GeometryContainer<Point>,
 }
 
 table! {
@@ -127,6 +131,7 @@ table! {
         multiline -> Geometry,
         multipolygon -> Geometry,
         geometrycollection -> Geometry,
+        geometrycontainer -> Geometry,
     }
 }
 
@@ -167,6 +172,7 @@ table! {
         multiline -> Geography,
         multipolygon -> Geography,
         geometrycollection -> Geography,
+        geometrycontainer -> Geography,
     }
 }
 fn establish_connection() -> PgConnection {
@@ -199,7 +205,8 @@ fn initialize() -> PgConnection {
     multipoint        geometry(MultiPoint,4326) NOT NULL,
     multiline         geometry(MultiLineString,4326) NOT NULL,
     multipolygon      geometry(MultiPolygon,4326) NOT NULL,
-    geometrycollection geometry(GeometryCollection,4326) NOT NULL
+    geometrycollection geometry(GeometryCollection,4326) NOT NULL,
+    geometrycontainer  geometry(Geometry,4326) NOT NULL
 )",
         )
         .execute(&mut conn);
@@ -228,7 +235,8 @@ fn initialize() -> PgConnection {
     multipoint        geography(MultiPoint,4326) NOT NULL,
     multiline         geography(MultiLineString,4326) NOT NULL,
     multipolygon      geography(MultiPolygon,4326) NOT NULL,
-    geometrycollection geography(GeometryCollection,4326) NOT NULL
+    geometrycollection geography(GeometryCollection,4326) NOT NULL,
+    geometrycontainer  geography(Geometry,4326) NOT NULL
 )",
         )
         .execute(&mut conn);
@@ -371,6 +379,7 @@ fn smoke_test() {
         multiline: multiline,
         multipolygon: multipolygon,
         geometrycollection: new_geometry_collection(),
+        geometrycontainer: GeometryContainer::Point(new_point(72.0, 64.0))
     };
     let point_from_db: GeometrySample = diesel::insert_into(geometry_samples::table)
         .values(&sample)
@@ -431,7 +440,7 @@ fn geography_smoke_test() {
         point_m: new_point_m(72.0, 64.0, 11.0),
         point_zm: new_point_zm(72.0, 64.0, 10.0, 11.0),
         linestring: new_line(vec![(72.0, 64.0), (73.0, 64.0)]),
-        polygon: polygon,
+        polygon: polygon.clone(),
         multipoint: MultiPoint {
             points: vec![new_point(72.0, 64.0), new_point(73.0, 64.0)],
             srid: Some(4326),
@@ -439,6 +448,7 @@ fn geography_smoke_test() {
         multiline: multiline,
         multipolygon: multipolygon,
         geometrycollection: new_geometry_collection(),
+        geometrycontainer: GeometryContainer::Polygon(polygon)
     };
     let point_from_db: GeographySample = diesel::insert_into(geography_samples::table)
         .values(&sample)
@@ -592,6 +602,7 @@ macro_rules! operator_test {
                 multiline: multiline,
                 multipolygon: multipolygon,
                 geometrycollection: new_geometry_collection(),
+                geometrycontainer: GeometryContainer::LineString(new_line(vec![(72.0, 64.0), (73.0, 64.0)])),
             };
             let _ = diesel::insert_into(geometry_samples::table)
                 .values(&sample)


### PR DESCRIPTION
I created this with #17 but decided to decouple the pull requests: This commit adds sql mappings (FromSql and ToSql) for GeometryContainer, meaning you can use it directly in your entity struct (as demonstrated in the integration test).