### PR TITLE
feat: Add support for generating json schemas using schemars

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ license = "MIT"
 diesel = { version = "2.0", features = ["postgres_backend"] }
 byteorder = "1.4"
 serde = { version = "1.0", optional = true, features = ["derive"] }
+schemars = { version = "0.8.20", optional = true }
 
 [dev-dependencies]
 diesel = { version = "2.0", features = ["postgres"] }
@@ -25,3 +26,4 @@ serde_json = "1.0"
 [features]
 serde = ["dep:serde"]
 serde_geojson = ["dep:serde"]
+schemars = ["dep:schemars"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,10 @@ extern crate diesel;
 #[macro_use]
 extern crate serde;
 
+#[cfg(feature = "schemars")]
+#[macro_use]
+extern crate schemars;
+
 mod ewkb;
 pub mod functions;
 pub mod functions_nullable;


### PR DESCRIPTION
Adds support for generating JsonSchema for types by applying `derive(JsonSchema)` macro. 

https://docs.rs/schemars/latest/schemars/

Hopefully the PR speaks for itself. I would like to preface that I am fairly new to the Rust language and package ecosystem, so let me know if there is anything that could be improved.

Cheers,
Jan