### PR TITLE
Remove default features, no 32-col tables by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diesel = { version = "2.0", features = ["postgres_backend"] }
+diesel = { version = "2.0", features = ["postgres_backend", "with-deprecated"], default-features = false }
 byteorder = "1.4"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
-diesel = { version = "2.0", features = ["postgres"] }
+diesel = { version = "2.0", features = ["postgres", "with-deprecated"], default-features = false }
 dotenvy = "0.15"
 serde_json = "1.0"
 


### PR DESCRIPTION
Diesel enables feature flags by default for 32-column tables - but if you don't need them, disabling them can improve compile times. Right now if you use this library, you can't disable that flag since it's inadvertently enabled here.

This just modifies `Cargo.toml` to avoid default features.