### PR TITLE
Derive `Clone`, `Copy` for SQL types

### DIFF
--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -13,7 +13,7 @@ use diesel::sql_types::SingleValue;
 ///    }
 ///}
 /// ```
-#[derive(SqlType, QueryId)]
+#[derive(SqlType, QueryId, Clone, Copy)]
 #[diesel(postgres_type(name = "geometry"))]
 pub struct Geometry;
 
@@ -29,7 +29,7 @@ pub struct Geometry;
 ///    }
 ///}
 /// ```
-#[derive(SqlType, QueryId)]
+#[derive(SqlType, QueryId, Clone, Copy)]
 #[diesel(postgres_type(name = "geography"))]
 pub struct Geography;
 


### PR DESCRIPTION
Hello, I have found that is is currently not possible to construct certain queries (such as joining tables based on result of a function like `ST_Intersect`) due to `Geometry`/`Geography` not implementing `Clone`.

Given that Diesel implements both `Clone` and `Copy` for its SQL types and that they are ZSTs, I have decided to add derives for them here as well.