### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diesel = { version = "2.2", features = ["postgres_backend", "with-deprecated"], default-features = false }
+diesel = { version = "2.2.3", features = ["postgres_backend", "with-deprecated"], default-features = false }
 byteorder = "1.4"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 schemars = { version = "0.8.20", optional = true }


### PR DESCRIPTION
Bumps the dependency to at least 2.2.3 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2024-0365.html)

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)