### PR TITLE
Making `diesel` feature-gated, but enabled by default

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,3 +28,11 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Rust test enabling serde
+      run: cargo test --features serde --verbose
+    - name: Rust test enabling serde_geojson
+      run: cargo test --features serde_geojson --verbose
+    - name: Rust test enabling schemars
+      run: cargo test --features schemars --verbose
+    - name: Rust check disabling default features
+      run: cargo check --no-default-features --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diesel = { version = "2.2.3", features = ["postgres_backend", "with-deprecated"], default-features = false }
+diesel = { version = "2.2.3", features = ["postgres_backend", "with-deprecated"], default-features = false, optional = true }
 byteorder = "1.4"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 schemars = { version = "0.8.20", optional = true }
@@ -24,6 +24,8 @@ dotenvy = "0.15"
 serde_json = "1.0"
 
 [features]
+default = ["diesel"]
 serde = ["dep:serde"]
 serde_geojson = ["dep:serde"]
 schemars = ["dep:schemars"]
+diesel = ["dep:diesel"]

--- a/src/geometrycollection.rs
+++ b/src/geometrycollection.rs
@@ -33,13 +33,13 @@ where
         }
     }
 
-    pub fn add_geometry<'a>(&'a mut self, geometry: GeometryContainer<T>) -> &mut Self {
+    pub fn add_geometry(&mut self, geometry: GeometryContainer<T>) -> &mut Self {
         self.geometries.push(geometry);
         self
     }
 
-    pub fn add_geometries<'a>(
-        &'a mut self,
+    pub fn add_geometries(
+        &mut self,
         geometries: impl IntoIterator<Item = GeometryContainer<T>>,
     ) -> &mut Self {
         for gc in geometries {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "diesel")]
 #[macro_use]
 extern crate diesel;
 #[cfg(any(feature = "serde", feature = "serde_geojson"))]
@@ -9,7 +10,9 @@ extern crate serde;
 extern crate schemars;
 
 mod ewkb;
+#[cfg(feature = "diesel")]
 pub mod functions;
+#[cfg(feature = "diesel")]
 pub mod functions_nullable;
 #[cfg(feature = "serde_geojson")]
 mod geojson;
@@ -19,6 +22,7 @@ mod linestring;
 mod multiline;
 mod multipoint;
 mod multipolygon;
+#[cfg(feature = "diesel")]
 pub mod operators;
 mod points;
 mod polygon;

--- a/src/linestring.rs
+++ b/src/linestring.rs
@@ -38,12 +38,12 @@ where
         }
     }
 
-    pub fn add_point<'a>(&'a mut self, point: T) -> &mut Self {
+    pub fn add_point(&mut self, point: T) -> &mut Self {
         self.points.push(point);
         self
     }
 
-    pub fn add_points<'a>(&'a mut self, points: impl IntoIterator<Item = T>) -> &mut Self {
+    pub fn add_points(&mut self, points: impl IntoIterator<Item = T>) -> &mut Self {
         for point in points {
             self.points.push(point);
         }

--- a/src/linestring.rs
+++ b/src/linestring.rs
@@ -2,16 +2,15 @@ use std::fmt::Debug;
 use std::io::Cursor;
 
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt, WriteBytesExt};
-use diesel::{
-    deserialize::{self, FromSql},
-    pg::{self, Pg},
-    serialize::{self, IsNull, Output, ToSql},
-};
 
-use crate::points::{read_point_coordinates, write_point_coordinates, Dimension};
+#[cfg(feature = "diesel")]
+use crate::ewkb::{read_ewkb_header, write_ewkb_header};
+use crate::points::Dimension;
+#[cfg(feature = "diesel")]
+use crate::points::{read_point_coordinates, write_point_coordinates};
 use crate::sql_types::*;
 use crate::{
-    ewkb::{read_ewkb_header, write_ewkb_header, EwkbSerializable, GeometryType, BIG_ENDIAN},
+    ewkb::{EwkbSerializable, GeometryType, BIG_ENDIAN},
     types::{LineString, PointT},
 };
 
@@ -60,11 +59,12 @@ where
     }
 }
 
-impl<T> FromSql<Geometry, Pg> for LineString<T>
+#[cfg(feature = "diesel")]
+impl<T> diesel::deserialize::FromSql<Geometry, diesel::pg::Pg> for LineString<T>
 where
     T: PointT + Debug + Clone,
 {
-    fn from_sql(bytes: pg::PgValue) -> deserialize::Result<Self> {
+    fn from_sql(bytes: diesel::pg::PgValue) -> diesel::deserialize::Result<Self> {
         let mut r = Cursor::new(bytes.as_bytes());
         let end = r.read_u8()?;
         if end == BIG_ENDIAN {
@@ -75,38 +75,48 @@ where
     }
 }
 
-impl<T> FromSql<Geography, Pg> for LineString<T>
+#[cfg(feature = "diesel")]
+impl<T> diesel::deserialize::FromSql<Geography, diesel::pg::Pg> for LineString<T>
 where
     T: PointT + Debug + Clone,
 {
-    fn from_sql(bytes: pg::PgValue) -> deserialize::Result<Self> {
-        FromSql::<Geometry, Pg>::from_sql(bytes)
+    fn from_sql(bytes: diesel::pg::PgValue) -> diesel::deserialize::Result<Self> {
+        diesel::deserialize::FromSql::<Geometry, diesel::pg::Pg>::from_sql(bytes)
     }
 }
 
-impl<T> ToSql<Geometry, Pg> for LineString<T>
+#[cfg(feature = "diesel")]
+impl<T> diesel::serialize::ToSql<Geometry, diesel::pg::Pg> for LineString<T>
 where
     T: PointT + Debug + EwkbSerializable,
 {
-    fn to_sql(&self, out: &mut Output<Pg>) -> serialize::Result {
+    fn to_sql(
+        &self,
+        out: &mut diesel::serialize::Output<diesel::pg::Pg>,
+    ) -> diesel::serialize::Result {
         write_linestring(self, self.srid, out)
     }
 }
 
-impl<T> ToSql<Geography, Pg> for LineString<T>
+#[cfg(feature = "diesel")]
+impl<T> diesel::serialize::ToSql<Geography, diesel::pg::Pg> for LineString<T>
 where
     T: PointT + Debug + EwkbSerializable,
 {
-    fn to_sql(&self, out: &mut Output<Pg>) -> serialize::Result {
+    fn to_sql(
+        &self,
+        out: &mut diesel::serialize::Output<diesel::pg::Pg>,
+    ) -> diesel::serialize::Result {
         write_linestring(self, self.srid, out)
     }
 }
 
+#[cfg(feature = "diesel")]
 pub fn write_linestring<T>(
     linestring: &LineString<T>,
     srid: Option<u32>,
-    out: &mut Output<Pg>,
-) -> serialize::Result
+    out: &mut diesel::serialize::Output<diesel::pg::Pg>,
+) -> diesel::serialize::Result
 where
     T: PointT + EwkbSerializable,
 {
@@ -116,10 +126,11 @@ where
     for point in linestring.points.iter() {
         write_point_coordinates(point, out)?;
     }
-    Ok(IsNull::No)
+    Ok(diesel::serialize::IsNull::No)
 }
 
-fn read_linestring<T, P>(cursor: &mut Cursor<&[u8]>) -> deserialize::Result<LineString<P>>
+#[cfg(feature = "diesel")]
+fn read_linestring<T, P>(cursor: &mut Cursor<&[u8]>) -> diesel::deserialize::Result<LineString<P>>
 where
     T: byteorder::ByteOrder,
     P: PointT + Clone,
@@ -128,11 +139,12 @@ where
     read_linestring_body::<T, P>(g_header.g_type, g_header.srid, cursor)
 }
 
+#[cfg(feature = "diesel")]
 pub fn read_linestring_body<T, P>(
     g_type: u32,
     srid: Option<u32>,
     cursor: &mut Cursor<&[u8]>,
-) -> deserialize::Result<LineString<P>>
+) -> diesel::deserialize::Result<LineString<P>>
 where
     T: byteorder::ByteOrder,
     P: PointT + Clone,

--- a/src/multiline.rs
+++ b/src/multiline.rs
@@ -32,16 +32,16 @@ where
         }
     }
 
-    pub fn add_line<'a>(&'a mut self) -> &mut Self {
+    pub fn add_line(&mut self) -> &mut Self {
         self.add_line_with_cap(0)
     }
 
-    pub fn add_line_with_cap<'a>(&'a mut self, cap: usize) -> &mut Self {
+    pub fn add_line_with_cap(&mut self, cap: usize) -> &mut Self {
         self.lines.push(LineString::with_capacity(self.srid, cap));
         self
     }
 
-    pub fn add_point<'a>(&'a mut self, point: T) -> &mut Self {
+    pub fn add_point(&mut self, point: T) -> &mut Self {
         if self.lines.last().is_none() {
             self.add_line();
         }
@@ -49,7 +49,7 @@ where
         self
     }
 
-    pub fn add_points<'a>(&'a mut self, points: impl IntoIterator<Item = T>) -> &mut Self {
+    pub fn add_points(&mut self, points: impl IntoIterator<Item = T>) -> &mut Self {
         if self.lines.last().is_none() {
             self.add_line();
         }

--- a/src/multipoint.rs
+++ b/src/multipoint.rs
@@ -1,19 +1,17 @@
 use std::fmt::Debug;
 use std::io::Cursor;
 
+#[cfg(feature = "diesel")]
+use crate::ewkb::{read_ewkb_header, write_ewkb_header};
 use crate::{
-    ewkb::{read_ewkb_header, write_ewkb_header, EwkbSerializable, GeometryType, BIG_ENDIAN},
-    points::{write_point, Dimension},
+    ewkb::{EwkbSerializable, GeometryType, BIG_ENDIAN},
+    points::Dimension,
     types::*,
 };
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt, WriteBytesExt};
-use diesel::{
-    deserialize::{self, FromSql},
-    pg::{self, Pg},
-    serialize::{self, IsNull, Output, ToSql},
-};
 
-use crate::points::read_point_coordinates;
+#[cfg(feature = "diesel")]
+use crate::points::{read_point_coordinates, write_point};
 use crate::sql_types::*;
 
 impl<T> MultiPoint<T>
@@ -65,11 +63,12 @@ where
     }
 }
 
-impl<T> FromSql<Geometry, Pg> for MultiPoint<T>
+#[cfg(feature = "diesel")]
+impl<T> diesel::deserialize::FromSql<Geometry, diesel::pg::Pg> for MultiPoint<T>
 where
     T: PointT + Debug + Clone,
 {
-    fn from_sql(bytes: pg::PgValue) -> deserialize::Result<Self> {
+    fn from_sql(bytes: diesel::pg::PgValue) -> diesel::deserialize::Result<Self> {
         let mut r = Cursor::new(bytes.as_bytes());
         let end = r.read_u8()?;
         if end == BIG_ENDIAN {
@@ -80,38 +79,48 @@ where
     }
 }
 
-impl<T> FromSql<Geography, Pg> for MultiPoint<T>
+#[cfg(feature = "diesel")]
+impl<T> diesel::deserialize::FromSql<Geography, diesel::pg::Pg> for MultiPoint<T>
 where
     T: PointT + Debug + Clone,
 {
-    fn from_sql(bytes: pg::PgValue) -> deserialize::Result<Self> {
-        FromSql::<Geometry, Pg>::from_sql(bytes)
+    fn from_sql(bytes: diesel::pg::PgValue) -> diesel::deserialize::Result<Self> {
+        diesel::deserialize::FromSql::<Geometry, diesel::pg::Pg>::from_sql(bytes)
     }
 }
 
-impl<T> ToSql<Geometry, Pg> for MultiPoint<T>
+#[cfg(feature = "diesel")]
+impl<T> diesel::serialize::ToSql<Geometry, diesel::pg::Pg> for MultiPoint<T>
 where
     T: PointT + Debug + EwkbSerializable,
 {
-    fn to_sql(&self, out: &mut Output<Pg>) -> serialize::Result {
+    fn to_sql(
+        &self,
+        out: &mut diesel::serialize::Output<diesel::pg::Pg>,
+    ) -> diesel::serialize::Result {
         write_multi_point(self, self.srid, out)
     }
 }
 
-impl<T> ToSql<Geography, Pg> for MultiPoint<T>
+#[cfg(feature = "diesel")]
+impl<T> diesel::serialize::ToSql<Geography, diesel::pg::Pg> for MultiPoint<T>
 where
     T: PointT + Debug + EwkbSerializable,
 {
-    fn to_sql(&self, out: &mut Output<Pg>) -> serialize::Result {
+    fn to_sql(
+        &self,
+        out: &mut diesel::serialize::Output<diesel::pg::Pg>,
+    ) -> diesel::serialize::Result {
         write_multi_point(self, self.srid, out)
     }
 }
 
+#[cfg(feature = "diesel")]
 pub fn write_multi_point<T>(
     multipoint: &MultiPoint<T>,
     srid: Option<u32>,
-    out: &mut Output<Pg>,
-) -> serialize::Result
+    out: &mut diesel::serialize::Output<diesel::pg::Pg>,
+) -> diesel::serialize::Result
 where
     T: PointT + EwkbSerializable,
 {
@@ -121,10 +130,11 @@ where
     for point in multipoint.points.iter() {
         write_point(point, None, out)?;
     }
-    Ok(IsNull::No)
+    Ok(diesel::serialize::IsNull::No)
 }
 
-fn read_multipoint<T, P>(cursor: &mut Cursor<&[u8]>) -> deserialize::Result<MultiPoint<P>>
+#[cfg(feature = "diesel")]
+fn read_multipoint<T, P>(cursor: &mut Cursor<&[u8]>) -> diesel::deserialize::Result<MultiPoint<P>>
 where
     T: byteorder::ByteOrder,
     P: PointT + Clone,
@@ -133,11 +143,12 @@ where
     read_multi_point_body::<T, P>(g_header.g_type, g_header.srid, cursor)
 }
 
+#[cfg(feature = "diesel")]
 pub fn read_multi_point_body<T, P>(
     g_type: u32,
     srid: Option<u32>,
     cursor: &mut Cursor<&[u8]>,
-) -> deserialize::Result<MultiPoint<P>>
+) -> diesel::deserialize::Result<MultiPoint<P>>
 where
     T: byteorder::ByteOrder,
     P: PointT + Clone,

--- a/src/multipoint.rs
+++ b/src/multipoint.rs
@@ -29,12 +29,12 @@ where
         }
     }
 
-    pub fn add_point<'a>(&'a mut self, point: T) -> &mut Self {
+    pub fn add_point(&mut self, point: T) -> &mut Self {
         self.points.push(point);
         self
     }
 
-    pub fn add_points<'a>(&'a mut self, points: impl IntoIterator<Item = T>) -> &mut Self {
+    pub fn add_points(&mut self, points: impl IntoIterator<Item = T>) -> &mut Self {
         for point in points {
             self.points.push(point);
         }

--- a/src/multipolygon.rs
+++ b/src/multipolygon.rs
@@ -30,11 +30,11 @@ where
         }
     }
 
-    pub fn add_empty_polygon<'a>(&'a mut self) -> &mut Self {
+    pub fn add_empty_polygon(&mut self) -> &mut Self {
         self.add_empty_polygon_with_capacity(0)
     }
 
-    pub fn add_empty_polygon_with_capacity<'a>(&'a mut self, cap: usize) -> &mut Self {
+    pub fn add_empty_polygon_with_capacity(&mut self, cap: usize) -> &mut Self {
         self.polygons.push(Polygon {
             rings: Vec::with_capacity(cap),
             srid: self.srid,
@@ -42,7 +42,7 @@ where
         self
     }
 
-    pub fn add_point<'a>(&'a mut self, point: T) -> &mut Self {
+    pub fn add_point(&mut self, point: T) -> &mut Self {
         if self.polygons.is_empty() {
             self.add_empty_polygon();
         }
@@ -50,7 +50,7 @@ where
         self
     }
 
-    pub fn add_points<'a>(&'a mut self, points: impl IntoIterator<Item = T>) -> &mut Self {
+    pub fn add_points(&mut self, points: impl IntoIterator<Item = T>) -> &mut Self {
         if self.polygons.is_empty() {
             self.add_empty_polygon();
         }

--- a/src/multipolygon.rs
+++ b/src/multipolygon.rs
@@ -1,18 +1,17 @@
 use std::fmt::Debug;
 use std::io::Cursor;
 
+#[cfg(feature = "diesel")]
 use crate::{
-    ewkb::{read_ewkb_header, write_ewkb_header, EwkbSerializable, GeometryType, BIG_ENDIAN},
-    points::Dimension,
+    ewkb::{read_ewkb_header, write_ewkb_header},
     polygon::{read_polygon_body, write_polygon},
+};
+use crate::{
+    ewkb::{EwkbSerializable, GeometryType, BIG_ENDIAN},
+    points::Dimension,
     types::*,
 };
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt, WriteBytesExt};
-use diesel::{
-    deserialize::{self, FromSql},
-    pg::{self, Pg},
-    serialize::{self, IsNull, Output, ToSql},
-};
 
 use crate::sql_types::*;
 
@@ -84,29 +83,38 @@ where
     }
 }
 
-impl<T> ToSql<Geometry, Pg> for MultiPolygon<T>
+#[cfg(feature = "diesel")]
+impl<T> diesel::serialize::ToSql<Geometry, diesel::pg::Pg> for MultiPolygon<T>
 where
     T: PointT + Debug + PartialEq + Clone + EwkbSerializable,
 {
-    fn to_sql(&self, out: &mut Output<Pg>) -> serialize::Result {
+    fn to_sql(
+        &self,
+        out: &mut diesel::serialize::Output<diesel::pg::Pg>,
+    ) -> diesel::serialize::Result {
         write_multi_polygon(self, self.srid, out)
     }
 }
 
-impl<T> ToSql<Geography, Pg> for MultiPolygon<T>
+#[cfg(feature = "diesel")]
+impl<T> diesel::serialize::ToSql<Geography, diesel::pg::Pg> for MultiPolygon<T>
 where
     T: PointT + Debug + PartialEq + Clone + EwkbSerializable,
 {
-    fn to_sql(&self, out: &mut Output<Pg>) -> serialize::Result {
+    fn to_sql(
+        &self,
+        out: &mut diesel::serialize::Output<diesel::pg::Pg>,
+    ) -> diesel::serialize::Result {
         write_multi_polygon(self, self.srid, out)
     }
 }
 
-impl<T> FromSql<Geometry, Pg> for MultiPolygon<T>
+#[cfg(feature = "diesel")]
+impl<T> diesel::deserialize::FromSql<Geometry, diesel::pg::Pg> for MultiPolygon<T>
 where
     T: PointT + Debug + Clone,
 {
-    fn from_sql(bytes: pg::PgValue) -> deserialize::Result<Self> {
+    fn from_sql(bytes: diesel::pg::PgValue) -> diesel::deserialize::Result<Self> {
         let mut r = Cursor::new(bytes.as_bytes());
         let end = r.read_u8()?;
         if end == BIG_ENDIAN {
@@ -116,20 +124,23 @@ where
         }
     }
 }
-impl<T> FromSql<Geography, Pg> for MultiPolygon<T>
+
+#[cfg(feature = "diesel")]
+impl<T> diesel::deserialize::FromSql<Geography, diesel::pg::Pg> for MultiPolygon<T>
 where
     T: PointT + Debug + Clone,
 {
-    fn from_sql(bytes: pg::PgValue) -> deserialize::Result<Self> {
-        FromSql::<Geometry, Pg>::from_sql(bytes)
+    fn from_sql(bytes: diesel::pg::PgValue) -> diesel::deserialize::Result<Self> {
+        diesel::deserialize::FromSql::<Geometry, diesel::pg::Pg>::from_sql(bytes)
     }
 }
 
+#[cfg(feature = "diesel")]
 pub fn write_multi_polygon<T>(
     multipolygon: &MultiPolygon<T>,
     srid: Option<u32>,
-    out: &mut Output<Pg>,
-) -> serialize::Result
+    out: &mut diesel::serialize::Output<diesel::pg::Pg>,
+) -> diesel::serialize::Result
 where
     T: PointT + EwkbSerializable + Clone,
 {
@@ -139,10 +150,13 @@ where
     for polygon in multipolygon.polygons.iter() {
         write_polygon(polygon, None, out)?;
     }
-    Ok(IsNull::No)
+    Ok(diesel::serialize::IsNull::No)
 }
 
-fn read_multi_polygon<T, P>(cursor: &mut Cursor<&[u8]>) -> deserialize::Result<MultiPolygon<P>>
+#[cfg(feature = "diesel")]
+fn read_multi_polygon<T, P>(
+    cursor: &mut Cursor<&[u8]>,
+) -> diesel::deserialize::Result<MultiPolygon<P>>
 where
     T: byteorder::ByteOrder,
     P: PointT + Clone,
@@ -151,11 +165,12 @@ where
     read_multi_polygon_body::<T, P>(g_header.g_type, g_header.srid, cursor)
 }
 
+#[cfg(feature = "diesel")]
 pub fn read_multi_polygon_body<T, P>(
     g_type: u32,
     srid: Option<u32>,
     cursor: &mut Cursor<&[u8]>,
-) -> deserialize::Result<MultiPolygon<P>>
+) -> diesel::deserialize::Result<MultiPolygon<P>>
 where
     T: byteorder::ByteOrder,
     P: PointT + Clone,

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -2,18 +2,17 @@ use std::fmt::Debug;
 use std::io::Cursor;
 
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt, WriteBytesExt};
-use diesel::{
-    deserialize::{self, FromSql},
-    pg::{self, Pg},
-    serialize::{self, IsNull, Output, ToSql},
-};
 
+#[cfg(feature = "diesel")]
+use crate::ewkb::{read_ewkb_header, write_ewkb_header};
 use crate::{
-    ewkb::{read_ewkb_header, write_ewkb_header, EwkbSerializable, GeometryType, BIG_ENDIAN},
+    ewkb::{EwkbSerializable, GeometryType, BIG_ENDIAN},
     types::{PointT, Polygon},
 };
 
-use crate::points::{read_point_coordinates, write_point_coordinates, Dimension};
+use crate::points::Dimension;
+#[cfg(feature = "diesel")]
+use crate::points::{read_point_coordinates, write_point_coordinates};
 use crate::sql_types::*;
 
 impl<T> Polygon<T>
@@ -79,29 +78,38 @@ where
     }
 }
 
-impl<T> ToSql<Geometry, Pg> for Polygon<T>
+#[cfg(feature = "diesel")]
+impl<T> diesel::serialize::ToSql<Geometry, diesel::pg::Pg> for Polygon<T>
 where
     T: PointT + Debug + PartialEq + Clone + EwkbSerializable,
 {
-    fn to_sql(&self, out: &mut Output<Pg>) -> serialize::Result {
+    fn to_sql(
+        &self,
+        out: &mut diesel::serialize::Output<diesel::pg::Pg>,
+    ) -> diesel::serialize::Result {
         write_polygon(self, self.srid, out)
     }
 }
 
-impl<T> ToSql<Geography, Pg> for Polygon<T>
+#[cfg(feature = "diesel")]
+impl<T> diesel::serialize::ToSql<Geography, diesel::pg::Pg> for Polygon<T>
 where
     T: PointT + Debug + PartialEq + Clone + EwkbSerializable,
 {
-    fn to_sql(&self, out: &mut Output<Pg>) -> serialize::Result {
+    fn to_sql(
+        &self,
+        out: &mut diesel::serialize::Output<diesel::pg::Pg>,
+    ) -> diesel::serialize::Result {
         write_polygon(self, self.srid, out)
     }
 }
 
+#[cfg(feature = "diesel")]
 pub fn write_polygon<T>(
     polygon: &Polygon<T>,
     srid: Option<u32>,
-    out: &mut Output<Pg>,
-) -> serialize::Result
+    out: &mut diesel::serialize::Output<diesel::pg::Pg>,
+) -> diesel::serialize::Result
 where
     T: PointT + EwkbSerializable + Clone,
 {
@@ -115,14 +123,15 @@ where
             write_point_coordinates(point, out)?;
         }
     }
-    Ok(IsNull::No)
+    Ok(diesel::serialize::IsNull::No)
 }
 
-impl<T> FromSql<Geometry, Pg> for Polygon<T>
+#[cfg(feature = "diesel")]
+impl<T> diesel::deserialize::FromSql<Geometry, diesel::pg::Pg> for Polygon<T>
 where
     T: PointT + Debug + Clone,
 {
-    fn from_sql(bytes: pg::PgValue) -> deserialize::Result<Self> {
+    fn from_sql(bytes: diesel::pg::PgValue) -> diesel::deserialize::Result<Self> {
         let mut r = Cursor::new(bytes.as_bytes());
         let end = r.read_u8()?;
         if end == BIG_ENDIAN {
@@ -133,16 +142,18 @@ where
     }
 }
 
-impl<T> FromSql<Geography, Pg> for Polygon<T>
+#[cfg(feature = "diesel")]
+impl<T> diesel::deserialize::FromSql<Geography, diesel::pg::Pg> for Polygon<T>
 where
     T: PointT + Debug + Clone,
 {
-    fn from_sql(bytes: pg::PgValue) -> deserialize::Result<Self> {
-        FromSql::<Geometry, Pg>::from_sql(bytes)
+    fn from_sql(bytes: diesel::pg::PgValue) -> diesel::deserialize::Result<Self> {
+        diesel::deserialize::FromSql::<Geometry, diesel::pg::Pg>::from_sql(bytes)
     }
 }
 
-fn read_polygon<T, P>(cursor: &mut Cursor<&[u8]>) -> deserialize::Result<Polygon<P>>
+#[cfg(feature = "diesel")]
+fn read_polygon<T, P>(cursor: &mut Cursor<&[u8]>) -> diesel::deserialize::Result<Polygon<P>>
 where
     T: byteorder::ByteOrder,
     P: PointT + Clone,
@@ -151,11 +162,12 @@ where
     read_polygon_body::<T, P>(g_header.g_type, g_header.srid, cursor)
 }
 
+#[cfg(feature = "diesel")]
 pub fn read_polygon_body<T, P>(
     g_type: u32,
     srid: Option<u32>,
     cursor: &mut Cursor<&[u8]>,
-) -> deserialize::Result<Polygon<P>>
+) -> diesel::deserialize::Result<Polygon<P>>
 where
     T: byteorder::ByteOrder,
     P: PointT + Clone,

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -30,16 +30,16 @@ where
         }
     }
 
-    pub fn add_ring<'a>(&'a mut self) -> &mut Self {
+    pub fn add_ring(&mut self) -> &mut Self {
         self.add_ring_with_capacity(0)
     }
 
-    pub fn add_ring_with_capacity<'a>(&'a mut self, cap: usize) -> &mut Self {
+    pub fn add_ring_with_capacity(&mut self, cap: usize) -> &mut Self {
         self.rings.push(Vec::with_capacity(cap));
         self
     }
 
-    pub fn add_point<'a>(&'a mut self, point: T) -> &mut Self {
+    pub fn add_point(&mut self, point: T) -> &mut Self {
         if self.rings.last().is_none() {
             self.add_ring();
         }
@@ -47,7 +47,7 @@ where
         self
     }
 
-    pub fn add_points<'a>(&'a mut self, points: impl IntoIterator<Item = T>) -> &mut Self {
+    pub fn add_points(&mut self, points: impl IntoIterator<Item = T>) -> &mut Self {
         if self.rings.last().is_none() {
             self.add_ring();
         }

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -1,5 +1,3 @@
-use diesel::sql_types::SingleValue;
-
 /// SQL type which may be used in table definition.
 /// ```
 ///#[macro_use] extern crate diesel;
@@ -13,8 +11,9 @@ use diesel::sql_types::SingleValue;
 ///    }
 ///}
 /// ```
-#[derive(SqlType, QueryId, Clone, Copy)]
-#[diesel(postgres_type(name = "geometry"))]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "diesel", derive(SqlType, QueryId))]
+#[cfg_attr(feature = "diesel", diesel(postgres_type(name = "geography")))]
 pub struct Geometry;
 
 /// SQL type which may be used in table definition.
@@ -29,12 +28,16 @@ pub struct Geometry;
 ///    }
 ///}
 /// ```
-#[derive(SqlType, QueryId, Clone, Copy)]
-#[diesel(postgres_type(name = "geography"))]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "diesel", derive(SqlType, QueryId))]
+#[cfg_attr(feature = "diesel", diesel(postgres_type(name = "geography")))]
 pub struct Geography;
 
-pub trait GeoType: SingleValue {}
+#[cfg(feature = "diesel")]
+pub trait GeoType: diesel::sql_types::SingleValue {}
 
+#[cfg(feature = "diesel")]
 impl GeoType for Geometry {}
 
+#[cfg(feature = "diesel")]
 impl GeoType for Geography {}

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -13,7 +13,7 @@
 /// ```
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "diesel", derive(SqlType, QueryId))]
-#[cfg_attr(feature = "diesel", diesel(postgres_type(name = "geography")))]
+#[cfg_attr(feature = "diesel", diesel(postgres_type(name = "geometry")))]
 pub struct Geometry;
 
 /// SQL type which may be used in table definition.

--- a/src/types.rs
+++ b/src/types.rs
@@ -36,9 +36,10 @@ impl std::error::Error for PointConstructorError {}
 ///     point: Point,
 /// }
 /// ```
-#[derive(Copy, Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
-#[diesel(sql_type = Geometry)]
-#[diesel(sql_type = Geography)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geometry))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geography))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Point {
@@ -58,9 +59,10 @@ pub struct Point {
 ///     point: PointZ,
 /// }
 /// ```
-#[derive(Copy, Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
-#[diesel(sql_type = Geometry)]
-#[diesel(sql_type = Geography)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geometry))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geography))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct PointZ {
@@ -81,9 +83,10 @@ pub struct PointZ {
 ///     point: PointM,
 /// }
 /// ```
-#[derive(Copy, Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
-#[diesel(sql_type = Geometry)]
-#[diesel(sql_type = Geography)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geometry))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geography))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct PointM {
@@ -104,9 +107,10 @@ pub struct PointM {
 ///     point: PointZM,
 /// }
 /// ```
-#[derive(Copy, Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
-#[diesel(sql_type = Geometry)]
-#[diesel(sql_type = Geography)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geometry))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geography))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct PointZM {
@@ -147,9 +151,10 @@ pub trait PointT {
 ///     multipoint: MultiPoint<Point>,
 /// }
 /// ```
-#[derive(Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
-#[diesel(sql_type = Geometry)]
-#[diesel(sql_type = Geography)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geometry))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geography))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct MultiPoint<T> {
@@ -168,9 +173,10 @@ pub struct MultiPoint<T> {
 ///     linestring: LineString<Point>,
 /// }
 /// ```
-#[derive(Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
-#[diesel(sql_type = Geometry)]
-#[diesel(sql_type = Geography)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geometry))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geography))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct LineString<T> {
@@ -189,9 +195,10 @@ pub struct LineString<T> {
 ///     multilinestring: MultiLineString<LineString<Point>>,
 /// }
 /// ```
-#[derive(Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
-#[diesel(sql_type = Geometry)]
-#[diesel(sql_type = Geography)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geometry))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geography))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct MultiLineString<T> {
@@ -210,9 +217,10 @@ pub struct MultiLineString<T> {
 ///     polygon: Polygon<Point>,
 /// }
 /// ```
-#[derive(Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
-#[diesel(sql_type = Geometry)]
-#[diesel(sql_type = Geography)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geometry))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geography))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Polygon<T> {
@@ -231,9 +239,10 @@ pub struct Polygon<T> {
 ///     multipolygon: MultiPolygon<Polygon<Point>>,
 /// }
 /// ```
-#[derive(Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
-#[diesel(sql_type = Geometry)]
-#[diesel(sql_type = Geography)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geometry))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geography))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct MultiPolygon<T> {
@@ -245,12 +254,21 @@ pub struct MultiPolygon<T> {
 /// Represents any type that can appear in a geometry or geography column.
 ///
 /// T is the Point type (Point or PointZ or PointM)
-#[derive(Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
-#[diesel(sql_type = Geometry)]
-#[diesel(sql_type = Geography)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geometry))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geography))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde_geojson", derive(Deserialize))]
-#[cfg_attr(feature = "serde_geojson", serde(tag = "type", bound(deserialize = "T: crate::geojson::GeoJsonGeometry<f64> + PointT + Clone + serde::Deserialize<'de>")))]
+#[cfg_attr(
+    feature = "serde_geojson",
+    serde(
+        tag = "type",
+        bound(
+            deserialize = "T: crate::geojson::GeoJsonGeometry<f64> + PointT + Clone + serde::Deserialize<'de>"
+        )
+    )
+)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub enum GeometryContainer<T> {
     Point(T),
@@ -272,9 +290,10 @@ pub enum GeometryContainer<T> {
 ///     geometrycollection: GeometryCollection<GeometryContainer<Point>>,
 /// }
 /// ```
-#[derive(Clone, Debug, PartialEq, FromSqlRow, AsExpression)]
-#[diesel(sql_type = Geometry)]
-#[diesel(sql_type = Geography)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geometry))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Geography))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct GeometryCollection<T> {
@@ -285,7 +304,12 @@ pub struct GeometryCollection<T> {
 
 #[cfg(feature = "serde_geojson")]
 #[derive(Clone, Debug, PartialEq, Deserialize)]
-#[serde(tag = "type", bound(deserialize = "T: crate::geojson::GeoJsonGeometry<f64> + PointT + Clone + serde::Deserialize<'de>, P: serde::Deserialize<'de>"))]
+#[serde(
+    tag = "type",
+    bound(
+        deserialize = "T: crate::geojson::GeoJsonGeometry<f64> + PointT + Clone + serde::Deserialize<'de>, P: serde::Deserialize<'de>"
+    )
+)]
 pub struct Feature<T, P: serde::Serialize> {
     pub id: Option<String>,
     pub geometry: Option<GeometryContainer<T>>,
@@ -294,7 +318,12 @@ pub struct Feature<T, P: serde::Serialize> {
 
 #[cfg(feature = "serde_geojson")]
 #[derive(Clone, Debug, PartialEq, Deserialize)]
-#[serde(tag = "type", bound(deserialize = "T: crate::geojson::GeoJsonGeometry<f64> + PointT + Clone + serde::Deserialize<'de>, P: serde::Deserialize<'de>"))]
+#[serde(
+    tag = "type",
+    bound(
+        deserialize = "T: crate::geojson::GeoJsonGeometry<f64> + PointT + Clone + serde::Deserialize<'de>, P: serde::Deserialize<'de>"
+    )
+)]
 pub struct FeatureCollection<T, P: serde::Serialize> {
     pub features: Vec<Feature<T, P>>,
 }
@@ -327,6 +356,5 @@ mod tests {
             let expected_schema_for_value = r#"{"$schema":"http://json-schema.org/draft-07/schema#","title":"Point","examples":[{"x":72.0,"y":64.0}],"type":"object","properties":{"x":{"type":"number"},"y":{"type":"number"}}}"#;
             assert_eq!(expected_schema_for_value, schema_for_value_json);
         }
-
     }
 }

--- a/tests/geom_accessors_functions_test.rs
+++ b/tests/geom_accessors_functions_test.rs
@@ -65,11 +65,19 @@ fn initialize() -> PgConnection {
         .execute(&mut conn);
         let north_sample = NewGeometrySample {
             name: "northern".to_string(),
-            point: Point { x: 1.0, y: 0.0, srid: Some(4326) },
+            point: Point {
+                x: 1.0,
+                y: 0.0,
+                srid: Some(4326),
+            },
         };
         let east_sample = NewGeometrySample {
             name: "eastern".to_string(),
-            point: Point { x: 0.0, y: 1.0, srid: Some(4326) },
+            point: Point {
+                x: 0.0,
+                y: 1.0,
+                srid: Some(4326),
+            },
         };
         let samples = vec![north_sample, east_sample];
         diesel::insert_into(geom_accessor_functions::table)

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -379,7 +379,7 @@ fn smoke_test() {
         multiline: multiline,
         multipolygon: multipolygon,
         geometrycollection: new_geometry_collection(),
-        geometrycontainer: GeometryContainer::Point(new_point(72.0, 64.0))
+        geometrycontainer: GeometryContainer::Point(new_point(72.0, 64.0)),
     };
     let point_from_db: GeometrySample = diesel::insert_into(geometry_samples::table)
         .values(&sample)
@@ -448,7 +448,7 @@ fn geography_smoke_test() {
         multiline: multiline,
         multipolygon: multipolygon,
         geometrycollection: new_geometry_collection(),
-        geometrycontainer: GeometryContainer::Polygon(polygon)
+        geometrycontainer: GeometryContainer::Polygon(polygon),
     };
     let point_from_db: GeographySample = diesel::insert_into(geography_samples::table)
         .values(&sample)
@@ -602,7 +602,10 @@ macro_rules! operator_test {
                 multiline: multiline,
                 multipolygon: multipolygon,
                 geometrycollection: new_geometry_collection(),
-                geometrycontainer: GeometryContainer::LineString(new_line(vec![(72.0, 64.0), (73.0, 64.0)])),
+                geometrycontainer: GeometryContainer::LineString(new_line(vec![
+                    (72.0, 64.0),
+                    (73.0, 64.0),
+                ])),
             };
             let _ = diesel::insert_into(geometry_samples::table)
                 .values(&sample)


### PR DESCRIPTION
In this pull request, I have introduced a feature called `diesel` which makes it possible to disable `diesel` in some circumstances such as when developing a monolithic web app which shares common structs between frontend and backend, as described in the issue #32.

Other than that, I have also resolved some code smells regarding lifetimes that were being elided, and made sure that the GitHub actions now do run tests also for the various optional feature or lack there of (when they are disabled).

This pull request closes issue #32 