### PR TITLE
Now using readme as module doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 #[cfg(feature = "diesel")]
 #[macro_use]
 extern crate diesel;


### PR DESCRIPTION
This prevents issues such as the one we had encountered in PR #34, where I had introduced a typo in the README. Now examples in the README are actually tested.