### PR TITLE
Fixes regression of #27 (32-column-tables flag)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diesel = { version = "2.2", optional = true }
+diesel = { version = "2.2", default-features = false, optional = true }
 byteorder = "1.4"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 schemars = { version = "0.8.20", optional = true }
 
 [dev-dependencies]
-diesel = { version = "2.2", features = ["returning_clauses_for_sqlite_3_35"] }
+diesel = { version = "2.2", features = ["returning_clauses_for_sqlite_3_35"], default-features = false }
 dotenvy = "0.15"
 serde_json = "1.0"
 
@@ -29,5 +29,5 @@ serde = ["dep:serde"]
 serde_geojson = ["serde"]
 schemars = ["dep:schemars"]
 diesel = ["dep:diesel"]
-postgres = ["diesel", "diesel/postgres"]
+postgres = ["diesel", "diesel/postgres_backend"]
 sqlite = ["diesel", "diesel/sqlite"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 schemars = { version = "0.8.20", optional = true }
 
 [dev-dependencies]
-diesel = { version = "2.2", features = ["returning_clauses_for_sqlite_3_35"], default-features = false }
+diesel = { version = "2.2", features = ["returning_clauses_for_sqlite_3_35"] }
 dotenvy = "0.15"
 serde_json = "1.0"
 


### PR DESCRIPTION
I noticed that when #35 was merged, it unfortunately brought back the `32-column-tables` flag that's default enabled on `diesel`. See #27 for more context on this.

This restores the behavior from #27 and also changes the `postgres` feature flag to use `diesel/postgres_backend` instead of `diesel/postgres`; the former seems to work fine and doesn't require a version of libpq for cases where it might be avoided.

(`diesel/postgres` just enables `diesel/postgres_backend` anyway)