### PR TITLE
Strip debug println! calls from MultiLineString read path

### DIFF
--- a/src/multiline.rs
+++ b/src/multiline.rs
@@ -133,19 +133,15 @@ where
         Endianness: byteorder::ByteOrder,
     {
         let lines_n = reader.read_u32::<Endianness>().unwrap();
-        println!("read lines_n: {:?}", lines_n);
         let mut multiline = MultiLineString::with_capacity(header.srid, lines_n as usize);
         for _i in 0..lines_n {
-            println!("read line");
             // skip 1 byte for byte order and 4 bytes for point type
             reader.read_u8().unwrap();
             reader.read_u32::<Endianness>().unwrap();
             let points_n = reader.read_u32::<Endianness>().unwrap();
-            println!("read points_n: {:?}", points_n);
             multiline.add_line_with_cap(points_n as usize);
             for _p in 0..points_n {
                 let point = P::read_body::<Endianness, Reader>(header, reader)?;
-                println!("read point {:?}", point);
                 multiline.add_point(point).unwrap();
             }
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -462,7 +462,6 @@ mod tests {
 
             let schema_for_value = schema_for_value!(point);
             let schema_for_value_json = serde_json::to_string(&schema_for_value).unwrap();
-            println!("{}", schema_for_value_json);
             let expected_schema_for_value = r#"{"$schema":"http://json-schema.org/draft-07/schema#","title":"Point","examples":[{"x":72.0,"y":64.0}],"type":"object","properties":{"x":{"type":"number"},"y":{"type":"number"}}}"#;
             assert_eq!(expected_schema_for_value, schema_for_value_json);
         }


### PR DESCRIPTION
`MultiLineString::read_body` in `src/multiline.rs` has four `println!` debug statements that fire on every read — at the start, once per line, once per line's point count, and once per point. For a typical PostGIS `MULTILINESTRING` read in production, this prints thousands of stdout lines per fetched row, drowning out any structured logging the application is using.

There's also a stray `println!` in `src/types.rs` inside the `Point` schemars test that produces noise during `cargo test`.

This PR removes all five `println!`s. No behavioural change beyond the removed prints; no test assertions reference the printed values.